### PR TITLE
Add branch_name parameter to /file_content in gh_interacter.py

### DIFF
--- a/gh_interacter/gh_interacter.py
+++ b/gh_interacter/gh_interacter.py
@@ -58,15 +58,16 @@ def get_pr_content():
 def get_file_content():
     repo_full_name = request.args.get('repo_full_name')
     file_path = request.args.get('file_path')
+    branch_name = request.args.get('branch_name', 'main')  # Default to 'main' if not specified
 
     if not repo_full_name or not file_path:
         return jsonify({'code': 400, 'message': 'Missing repo_full_name or file_path'}), 400
 
-    github_api_url = f"https://api.github.com/repos/{repo_full_name}/contents/{file_path}"
+    github_api_url = f"https://api.github.com/repos/{repo_full_name}/contents/{file_path}?ref={branch_name}"
     response = requests.get(github_api_url)
 
     if response.status_code != 200:
-        return jsonify({'code': response.status_code, 'message': 'Failed to fetch file content'}), response.status_code
+        return jsonify({'code': response.status_code, 'message': f'Failed to fetch file content from {branch_name} branch'}), response.status_code
 
     file_content_encoded = response.json().get('content')
     if file_content_encoded is None:

--- a/gh_interacter/openapi.yaml
+++ b/gh_interacter/openapi.yaml
@@ -66,6 +66,13 @@ paths:
           required: true
           schema:
             type: string
+        - name: branch_name  # New parameter added
+          in: query
+          description: Name of the repository branch
+          required: false
+          schema:
+            type: string
+            default: 'main'
       responses:
         '200':
           description: Full content of the specified file


### PR DESCRIPTION
- Updated the /file_content endpoint to accept an optional branch_name parameter.
- Set the default value for branch_name to 'main' for backward compatibility.
- Modified the GitHub API URL in the get_file_content function to use the specified branch.
- Improved error handling and messaging in the get_file_content function.
- Corresponding updates made to openapi.yaml documentation.
- This change resolves Issue #48, addressing the 404 error when fetching files not in the main branch.